### PR TITLE
10.0.2

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,26 +1,26 @@
 {
-	"EffectMacro": {
-		"ApplyMacro": {
-			"Save": "Save Script",
-			"Command": "Command",
-			"EditImgError": "Error in edit image."
-		},
-		"Warning": {
-			"NoSuchScript": "No such script embedded in effect.",
-			"NoScriptProvided": "You did not provide a function."
-		},
-		"Label": {
-			"never": "Never Automatically",
-			"onCreate": "On Effect Creation",
-			"onDelete": "On Effect Deletion",
-			"onToggle": "On Effect Toggle (on or off)",
-			"onEnable": "On Effect Toggle (on)",
-			"onDisable": "On Effect Toggle (off)",
-			"onTurnStart": "On Combat Turn Starting",
-			"onTurnEnd": "On Combat Turn Ending",
-			"onCombatStart": "On Combat Starting",
-			"onCombatEnd": "On Combat Ending",
-			"onCombatantDefeated": "On Combatant Marked Defeated"
-		}
-	}
+    "EFFECTMACRO": {
+        "APPLYMACRO": {
+            "SAVE": "Save Script",
+            "COMMAND": "Command",
+            "EDIT_IMGE_RROR": "Error in edit image."
+        },
+        "WARNING": {
+            "NO_SUCH_SCRIPT": "No such script embedded in effect.",
+            "NO_SCRIPT_PROVIDED": "You did not provide a function."
+        },
+        "LABEL": {
+            "never": "Never Automatically",
+            "onCreate": "On Effect Creation",
+            "onDelete": "On Effect Deletion",
+            "onToggle": "On Effect Toggle (on or off)",
+            "onEnable": "On Effect Toggle (on)",
+            "onDisable": "On Effect Toggle (off)",
+            "onTurnStart": "On Combat Turn Starting",
+            "onTurnEnd": "On Combat Turn Ending",
+            "onCombatStart": "On Combat Starting",
+            "onCombatEnd": "On Combat Ending",
+            "onCombatantDefeated": "On Combatant Marked Defeated"
+        }
+    }
 }

--- a/module.json
+++ b/module.json
@@ -31,5 +31,7 @@
     ],
     "url": "https://github.com/krbz999/effectmacro",
     "manifest": "https://github.com/krbz999/effectmacro/releases/latest/download/module.json",
-    "download": "https://github.com/krbz999/effectmacro/releases/download/v10.0.2/module.zip"
+    "download": "https://github.com/krbz999/effectmacro/releases/download/v10.0.2/module.zip",
+    "name": "effectmacro",
+    "minimumCoreVersion": "10"
 }

--- a/module.json
+++ b/module.json
@@ -1,7 +1,7 @@
 {
     "id": "effectmacro",
     "title": "Effect Macro",
-    "version": "10.0.1",
+    "version": "10.0.2",
     "authors": [
         {
             "name": "Zhell",
@@ -12,27 +12,24 @@
     ],
     "compatibility": {
         "minimum": "10",
-        "verified": "10",
-        "maximum": "10"
+        "maximum": "10",
+        "verified": "10.285"
     },
     "esmodules": [
-        "./setup.js"
+        "setup.js"
     ],
     "styles": [
-        "./styles/styles.css"
+        "styles/styles.css"
     ],
     "languages": [
         {
             "lang": "en",
             "name": "English",
             "path": "lang/en.json",
-            "title": "Effect Macro",
-            "description": "Grants the ability to add multiple scripts onto effects to execute at will or automatically."
+            "flags": {}
         }
     ],
     "url": "https://github.com/krbz999/effectmacro",
     "manifest": "https://github.com/krbz999/effectmacro/releases/latest/download/module.json",
-    "download": "https://github.com/krbz999/effectmacro/releases/download/v10.0.1/module.zip",
-    "name": "effectmacro",
-    "minimumCoreVersion": "10"
+    "download": "https://github.com/krbz999/effectmacro/releases/download/v10.0.2/module.zip"
 }

--- a/readme.md
+++ b/readme.md
@@ -18,20 +18,12 @@ An effect can have a macro of any of these types, not just one. There is also th
 Macros are added in the ActiveEffect config. Selecting the type of trigger and clicking the arrow (or green check if there is a preexisting macro) opens a macro editor.
 
 <p align="center">
-  <img src="https://i.imgur.com/zK1LFHA.png"/>
+    <img src="https://i.imgur.com/zK1LFHA.png"/>
 </p>
 
 When an embedded macro is triggered, it is executed for the one triggering the event, or in the case of combat events for the first active player owner found, otherwise as the GM.
 
-### Added functions
-A set of functions have been added to active effects.
-* `ActiveEffect#callMacro` calls a macro embedded in the effect of the specific type. The `context` object can be used to pass additional parameters to the script, and can be referenced with `this`.
-* `ActiveEffect#hasMacro` returns true or false whether or not an effect has a macro of the given type.
-* `ActiveEffect#removeMacro` removes a macro of the given type from the effect.
-* `ActiveEffect#createMacro` creates an embedded macro of the given type inside the effect. Identical to using the provided interface and writing a macro there. The provided script must be a string.
-* `ActiveEffect#updateMacro` updates a macro of the given type on an effect. In most cases functionally identical to `createMacro`, and will remove the embedded macro if no script is provided. The provided script must be a string.
-
-### Script Helpers
+## Script Helpers
 By default, these variables are pre-defined in any effect macro.
 * `actor`, the owner of the effect.
 * `character`, the assigned character of the user who triggered the macro (if they have any), otherwise the owner of the effect.
@@ -39,3 +31,11 @@ By default, these variables are pre-defined in any effect macro.
 * `scene`, the current scene where `token` exists, otherwise the currently active scene.
 * `origin`, the actor or item who is the origin of the effect (as seen under Source in the Effects tab of the actor), otherwise the owner of the effect.
 * `effect`, the active effect itself.
+
+## Added functions
+A set of functions have been added to active effects.
+* `ActiveEffect#callMacro` calls a macro embedded in the effect of the specific type. The `context` object can be used to pass additional parameters to the script, and can be referenced with `this`.
+* `ActiveEffect#hasMacro` returns true or false whether or not an effect has a macro of the given type.
+* `ActiveEffect#removeMacro` removes a macro of the given type from the effect.
+* `ActiveEffect#createMacro` creates an embedded macro of the given type inside the effect. Identical to using the provided interface and writing a macro there. The provided script must be a string.
+* `ActiveEffect#updateMacro` updates a macro of the given type on an effect. In most cases functionally identical to `createMacro`, and will remove the embedded macro if no script is provided. The provided script must be a string.

--- a/scripts/macroConfig.mjs
+++ b/scripts/macroConfig.mjs
@@ -12,7 +12,7 @@ export function registerMacroConfig(){
 
         const options = TRIGGERS.map(key => {
             const selected = foundry.utils.getProperty(dialog, `${MODULE}.lastUpdated`) === key && "selected";
-            const label = game.i18n.localize(`EffectMacro.Label.${key}`);
+            const label = game.i18n.localize(`EFFECTMACRO.LABEL.${key}`);
             const optionClass = effect.hasMacro(key) ? "effectmacro-option-has-macro" : "effectmacro-option-no-macro";
             return {key, selected, label, optionClass};
         }).sort((a, b) => {
@@ -39,9 +39,9 @@ export function registerMacroConfig(){
         html[0].querySelector(".effectmacro-config-button").addEventListener("click", () => {
             const type = html[0].querySelector(".effectmacro-config-select").value;
             foundry.utils.setProperty(dialog, `${MODULE}.lastUpdated`, type);
-            new EffectMacroConfig(dialog.document, {type}).render(true);
+            new EffectMacroConfig(dialog.document, { type }).render(true);
         });
         
-        dialog.element.css("height", "auto");
+        dialog.setPosition();
     });
 }

--- a/scripts/main.mjs
+++ b/scripts/main.mjs
@@ -126,6 +126,11 @@ export class API {
             return ui.notifications.warn(game.i18n.localize("EFFECTMACRO.WARNNG.NO_SCRIPT_PROVIDED"));
         }
         else {
+            if ( script instanceof Function ) {
+                return this.setFlag(MODULE, `${type}.script`, `(
+                    ${script.toString()}
+                )()`);
+            }
             return this.setFlag(MODULE, `${type}.script`, script.toString());
         }
     }

--- a/scripts/main.mjs
+++ b/scripts/main.mjs
@@ -1,175 +1,175 @@
 import { MODULE } from "./constants.mjs";
 
 export class EM {
-	
-	// take a string and execute it after turning it into a script.
-	static executeScripts = async (eff, scripts, context = {}) => {
-		if ( scripts.size < 1 ) return;
-		
-		// define helper variables.
-		let {actor, character, token, scene, origin, effect} = await this.getHelperVariables(eff);
-		
-		for ( let {script} of Object.values(scripts) ) {
-			const body = `(async()=>{
-				${script}
-			})();`;
-			const fn = Function("token", "character", "actor", "scene", "origin", "effect", body);
-			await fn.call(context, token, character, actor, scene, origin, effect);
-		}
-		
-	}
-	
-	// prime context to execute script (in pre hooks).
-	static primer = (context, type) => {
-		if ( !context.effectmacro ) context.effectmacro = [type];
-		else context.effectmacro.push(type);
-	}
-	
-	// get the scripts.
-	static getScripts = (effect, types, context) => {
-		const scripts = {};
-		for ( let type of types ) {
-			scripts[type] = effect.getFlag("effectmacro", type);
-		}
-		return this.executeScripts(effect, scripts, context);
-	}
-	
-	// get helper variables.
-	static getHelperVariables = async (effect) => {
-		let actor = effect.parent;
-		let character = game.user.character ?? actor;
-		let token = actor.token?.object ?? actor.getActiveTokens()[0];
-		let scene = token?.scene ?? game.scenes.active;
-		let origin = effect.origin ? await fromUuid(effect.origin) : actor;
-		
-		return {actor, character, token, scene, origin, effect};
-	}
-	
+    
+    // take a string and execute it after turning it into a script.
+    static executeScripts = async (eff, scripts, context = {}) => {
+        if ( scripts.size < 1 ) return;
+        
+        // define helper variables.
+        let {actor, character, token, scene, origin, effect} = await this.getHelperVariables(eff);
+        
+        for ( let {script} of Object.values(scripts) ) {
+            const body = `(async()=>{
+                ${script}
+            })();`;
+            const fn = Function("token", "character", "actor", "scene", "origin", "effect", body);
+            await fn.call(context, token, character, actor, scene, origin, effect);
+        }
+        
+    }
+    
+    // prime context to execute script (in pre hooks).
+    static primer = (context, type) => {
+        if ( !context.effectmacro ) context.effectmacro = [type];
+        else context.effectmacro.push(type);
+    }
+    
+    // get the scripts.
+    static getScripts = (effect, types, context) => {
+        const scripts = {};
+        for ( let type of types ) {
+            scripts[type] = effect.getFlag("effectmacro", type);
+        }
+        return this.executeScripts(effect, scripts, context);
+    }
+    
+    // get helper variables.
+    static getHelperVariables = async (effect) => {
+        let actor = effect.parent;
+        let character = game.user.character ?? actor;
+        let token = actor.token?.object ?? actor.getActiveTokens()[0];
+        let scene = token?.scene ?? game.scenes.active;
+        let origin = effect.origin ? await fromUuid(effect.origin) : actor;
+        
+        return {actor, character, token, scene, origin, effect};
+    }
+    
 }
 
 export class CHECKS {
-	
-	// does effect have actor parent and is it NOT suppressed?
-	static verifyEffect = (effect) => {
-		return ( effect.parent instanceof Actor ) && ( effect.isSuppressed === false );
-	}
+    
+    // does effect have actor parent and is it NOT suppressed?
+    static verifyEffect = (effect) => {
+        return ( effect.parent instanceof Actor ) && ( effect.isSuppressed === false );
+    }
 
-	// was this an effect that got toggled ON?
-	static toggledOn = (effect, update) => {
-		const wasOff = effect.disabled === true;
-		const isOn = update.disabled === false;
-		return ( wasOff && isOn );
-	}
-	
-	// was this an effect that got toggled OFF?
-	static toggledOff = (effect, update) => {
-		const wasOn = effect.disabled === false;
-		const isOff = update.disabled === true;
-		return ( wasOn && isOff );
-	}
-	
-	// was this an effect that got toggled?
-	static toggled = (effect, update) => {
-		return this.toggledOn(effect, update) || this.toggledOff(effect, update);
-	}
-	
-	// does it have a script of a certain type?
-	static hasMacroOfType = (effect, type, verifySupression = true) => {
-		// must be on an actor, and must be non-suppressed (in case of unequipped/unattuned items)
-		if ( verifySupression && !this.verifyEffect(effect) ) return false;
-		const embedded = effect.getFlag(MODULE, `${type}.script`) ?? "";
-		return embedded;
-	}
-	
-	// is this effect active (not disabled)?
-	static isActive = (effect) => {
-		return !effect.disabled;
-	}
-	
-	// get first active player (id) who owns the actor.
-	static firstPlayerOwner = (actor) => {
-		if ( !actor.hasPlayerOwner ) return false;
-		const active_players = game.users.filter(i => !i.isGM && i.active);
-		const {OWNER} = CONST.DOCUMENT_OWNERSHIP_LEVELS;
-		for ( let p of active_players ) {
-			if ( actor.testUserPermission(p, OWNER) ) return p.id;
-		}
-		return false;
-	}
-	
+    // was this an effect that got toggled ON?
+    static toggledOn = (effect, update) => {
+        const wasOff = effect.disabled === true;
+        const isOn = update.disabled === false;
+        return ( wasOff && isOn );
+    }
+    
+    // was this an effect that got toggled OFF?
+    static toggledOff = (effect, update) => {
+        const wasOn = effect.disabled === false;
+        const isOff = update.disabled === true;
+        return ( wasOn && isOff );
+    }
+    
+    // was this an effect that got toggled?
+    static toggled = (effect, update) => {
+        return this.toggledOn(effect, update) || this.toggledOff(effect, update);
+    }
+    
+    // does it have a script of a certain type?
+    static hasMacroOfType = (effect, type, verifySupression = true) => {
+        // must be on an actor, and must be non-suppressed (in case of unequipped/unattuned items)
+        if ( verifySupression && !this.verifyEffect(effect) ) return false;
+        const embedded = effect.getFlag(MODULE, `${type}.script`) ?? "";
+        return embedded;
+    }
+    
+    // is this effect active (not disabled)?
+    static isActive = (effect) => {
+        return !effect.disabled;
+    }
+    
+    // get first active player (id) who owns the actor.
+    static firstPlayerOwner = (actor) => {
+        if ( !actor.hasPlayerOwner ) return false;
+        const active_players = game.users.filter(i => !i.isGM && i.active);
+        const {OWNER} = CONST.DOCUMENT_OWNERSHIP_LEVELS;
+        for ( let p of active_players ) {
+            if ( actor.testUserPermission(p, OWNER) ) return p.id;
+        }
+        return false;
+    }
+    
 }
 
 export class API {
-	
-	// call a specific type of script in an effect.
-	static callMacro = function(type = "never", context = {}){
-		const script = this.getFlag(MODULE, type);
-		if ( !script ) return ui.notifications.warn(game.i18n.localize("EffectMacro.Warning.NoSuchScript"));
-		return EM.getScripts(this, [type], context);
-	}
-	
-	// return true or false if has macro of specific type.
-	static hasMacro = function(type = "never"){
-		return !!this.getFlag(MODULE, `${type}.script`);
-	}
-	
-	// remove a specific type of script in an effect.
-	static removeMacro = function(type = "never"){
-		const script = this.getFlag(MODULE, type);
-		if ( !script ) return ui.notifications.warn(game.i18n.localize("EffectMacro.Warning.NoSuchScript"));
-		return this.unsetFlag(MODULE, type);
-	}
-	
-	// create a function on the effect.
-	static createMacro = function(type = "never", script){
-		if ( !script ) {
-			return ui.notifications.warn(game.i18n.localize("EffectMacro.Warning.NoScriptProvided"));
-		}
-		else {
-			return this.setFlag(MODULE, `${type}.script`, script.toString());
-		}
-	}
-	
-	// update a function on the effect.
-	static updateMacro = function(type = "never", script){
-		if ( script.toString() !== this.getFlag(MODULE, `${type}.script`) ) {
-			return this.setFlag(MODULE, `${type}.script`, script.toString());
-		}
-	}
+    
+    // call a specific type of script in an effect.
+    static callMacro = function(type = "never", context = {}){
+        const script = this.getFlag(MODULE, type);
+        if ( !script ) return ui.notifications.warn(game.i18n.localize("EFFECTMACRO.WARNNG.NO_SUCH_SCRIPT"));
+        return EM.getScripts(this, [type], context);
+    }
+    
+    // return true or false if has macro of specific type.
+    static hasMacro = function(type = "never"){
+        return !!this.getFlag(MODULE, `${type}.script`);
+    }
+    
+    // remove a specific type of script in an effect.
+    static removeMacro = function(type = "never"){
+        const script = this.getFlag(MODULE, type);
+        if ( !script ) return ui.notifications.warn(game.i18n.localize("EFFECTMACRO.WARNNG.NO_SUCH_SCRIPT"));
+        return this.unsetFlag(MODULE, type);
+    }
+    
+    // create a function on the effect.
+    static createMacro = function(type = "never", script){
+        if ( !script ) {
+            return ui.notifications.warn(game.i18n.localize("EFFECTMACRO.WARNNG.NO_SCRIPT_PROVIDED"));
+        }
+        else {
+            return this.setFlag(MODULE, `${type}.script`, script.toString());
+        }
+    }
+    
+    // update a function on the effect.
+    static updateMacro = function(type = "never", script){
+        if ( script.toString() !== this.getFlag(MODULE, `${type}.script`) ) {
+            return this.setFlag(MODULE, `${type}.script`, script.toString());
+        }
+    }
 }
 
 export class EffectMacroConfig extends MacroConfig {
-	constructor(doc, options){
-		super(doc, {});
-		this.type = options.type;
-	}
-	
-	/* Override */
-	static get defaultOptions(){
-		return mergeObject(super.defaultOptions, {
-			id: "effectmacro-menu",
-			template: "modules/effectmacro/templates/macro-menu.html",
-			classes: ["macro-sheet", "sheet"]
-		});
-	}
-	
-	/* Override */
-	async getData(){
-		const data = super.getData();
-		data.img = this.object.icon;
-		data.name = this.object.label;
-		data.script = this.object.getFlag(MODULE, this.type)?.script ?? "";
-		return data;
-	}
-	
-	/* Override */
-	_onEditImage(event){
-		return ui.notifications.error(game.i18n.localize("EffectMacro.ApplyMacro.EditImgError"));
-	}
-	
-	/* Override */
-	async _updateObject(event, formData){
-		const type = this.type;
-		await this.object.updateMacro(type, formData.command);
-	}
+    constructor(doc, options){
+        super(doc, {});
+        this.type = options.type;
+    }
+    
+    /* Override */
+    static get defaultOptions(){
+        return foundry.utils.mergeObject(super.defaultOptions, {
+            id: "effectmacro-menu",
+            template: "modules/effectmacro/templates/macro-menu.html",
+            classes: ["macro-sheet", "sheet"]
+        });
+    }
+    
+    /* Override */
+    async getData(){
+        const data = super.getData();
+        data.img = this.object.icon;
+        data.name = this.object.label;
+        data.script = this.object.getFlag(MODULE, this.type)?.script ?? "";
+        return data;
+    }
+    
+    /* Override */
+    _onEditImage(event){
+        return ui.notifications.error(game.i18n.localize("EFFECTMACRO.APPLYMACRO.EDIT_IMG_ERROR"));
+    }
+    
+    /* Override */
+    async _updateObject(event, formData){
+        const type = this.type;
+        return this.object.updateMacro(type, formData.command);
+    }
 }

--- a/scripts/triggers/combat.mjs
+++ b/scripts/triggers/combat.mjs
@@ -1,8 +1,6 @@
 import { MODULE } from "../constants.mjs";
 import { CHECKS } from "../main.mjs";
 
-
-
 export function registerCombatTriggers(){
     // helper hook to get previous combatant.
     Hooks.on("preUpdateCombat", (combat, _, context) => {

--- a/scripts/triggers/combat.mjs
+++ b/scripts/triggers/combat.mjs
@@ -1,73 +1,56 @@
+import { MODULE } from "../constants.mjs";
 import { CHECKS } from "../main.mjs";
 
 
 
 export function registerCombatTriggers(){
-    // onTurnStart/End is special and weird and has to do it all on its own, but we love him all the same.
-    Hooks.on("updateCombat", async (combat, changes) => {
+    // helper hook to get previous combatant.
+    Hooks.on("preUpdateCombat", (combat, _, context) => {
+        const previousId = combat.combatant?.id;
+        foundry.utils.setProperty(context, `${MODULE}.previousCombatant`, previousId);
+    });
+    // onTurnStart/End is no longer so special and weird and doesn't have to do it all on its own
+    // yet we still love him all the same.
+    Hooks.on("updateCombat", async (combat, changes, context) => {
         // no change in turns nor rounds.
         if ( changes.turn === undefined && changes.round === undefined ) return;
-        
         // combat not started.
         if ( !combat.started ) return;
-        
         // not active combat.
         if ( !combat.isActive ) return;
-        
         // we went back.
         if ( combat.current.round < combat.previous.round ) return;
-        
         // we went back.
         if ( combat.current.turn < combat.previous.turn && combat.current.round === combat.previous.round ) return;
         
-        // current and previous combatant ids.
-        const currentId = combat.current.combatantId;
-        const previousId = combat.previous.combatantId;
-        
-        // current and previous combatants:
-        const currentCombatant = combat.combatants.get(currentId);
+        // retrieve combatants.
+        const currentCombatant = combat.combatant;
+        const previousId = context[MODULE].previousCombatant;
         const previousCombatant = combat.combatants.get(previousId);
         
-        // current and previous ACTORS in combat.
-        const actorCurrent = currentCombatant.token.actor;
-        const actorPrevious = previousCombatant?.token.actor;
-        
         // find active effects with onTurn triggers.
-        const effectsStart = actorCurrent.effects.filter(eff => {
-            return !!CHECKS.hasMacroOfType(eff, "onTurnStart") && CHECKS.isActive(eff);
+        const effectsStart = currentCombatant.token.actor.effects.filter(eff => {
+            return CHECKS.hasMacroOfType(eff, "onTurnStart") && CHECKS.isActive(eff);
         });
-        const effectsEnd = actorPrevious?.effects.filter(eff => {
-            return !!CHECKS.hasMacroOfType(eff, "onTurnEnd") && CHECKS.isActive(eff);
+        const effectsEnd = previousCombatant?.token.actor?.effects.filter(eff => {
+            return CHECKS.hasMacroOfType(eff, "onTurnEnd") && CHECKS.isActive(eff);
         }) ?? [];
         
-        // get active player who is owner of combatant.
-        const playerCurrent = currentCombatant.players.filter(i => i.active)[0];
-        const playerPrevious = previousCombatant?.players.filter(i => i.active)[0];
-        
-        // are you the player owner of current combatant? if not, are you gm?
-        if ( !!currentCombatant ) {
-            if ( game.user === playerCurrent ) for ( let eff of effectsStart ) await eff.callMacro("onTurnStart");
-            else if ( !playerCurrent && game.user.isGM ) for ( let eff of effectsStart ) await eff.callMacro("onTurnStart");
+        // call scripts.
+        if ( currentCombatant ) {
+            if ( game.user === getFirstPlayerOwner(currentCombatant) ) {
+                for ( const eff of effectsStart ) await eff.callMacro("onTurnStart");
+            }
         }
-        
-        // are you the player owner of previous combatant? if not, are you gm?
-        if ( !!previousCombatant ) {
-            if ( game.user === playerPrevious ) for ( let eff of effectsEnd ) await eff.callMacro("onTurnEnd");
-            else if ( !playerPrevious && game.user.isGM ) for ( let eff of effectsEnd ) await eff.callMacro("onTurnEnd");
+        if ( previousCombatant ) {
+            if ( game.user === getFirstPlayerOwner(previousCombatant) ) {
+                for ( const eff of effectsEnd ) await eff.callMacro("onTurnEnd");
+            }
         }
     });
 
     // onCombatStart
-    Hooks.on("updateCombat", async (combat, update) => {
-        // current must be round1, turn0.
-        if ( combat.current.round !== 1 || combat.current.turn !== 0 ) return;
-        // previous turn must be round0, turn null.
-        if ( combat.previous.round !== 0 || combat.previous.turn !== null ) return;
-        // must be active combat now.
-        if ( !combat.isActive ) return;
-        // must be a started combat.
-        if ( !combat.started ) return;
-        
+    Hooks.on("combatStart", async (combat) => {
         // all combatants that have 'onCombatStart' effects.
         const combatants = combat.combatants.reduce((acc, c) => {
             const effects = c.actor.effects.filter(e => {
@@ -80,13 +63,10 @@ export function registerCombatTriggers(){
         }, []);
         
         // for each eligible combatant...
-        for ( let [combatant, effects] of combatants ) {
-            // get active player who is owner of combatant.
-            const owner = combatant.players.filter(i => i.active)[0];
-            // if there is an active player, and that's you, you call this.
-            if ( owner === game.user) for ( let eff of effects ) await eff.callMacro("onCombatStart");
-            // else the gm calls it.
-            else if ( !owner && game.user.isGM ) for ( let eff of effects ) await eff.callMacro("onCombatStart");
+        for ( const [combatant, effects] of combatants ) {
+            // compare against the user who should call these scripts.
+            if ( game.user !== getFirstPlayerOwner(combatant) ) continue;
+            for ( const eff of effects ) await eff.callMacro("onCombatStart");
         }
     });
 
@@ -109,13 +89,10 @@ export function registerCombatTriggers(){
         }, []);
         
         // for each eligible combatant...
-        for ( let [combatant, effects] of combatants ) {
-            // get active player who is owner of combatant.
-            const owner = combatant.players.filter(i => i.active)[0];
-            // if there is an active player, and that's you, you call this.
-            if ( owner === game.user ) for ( let eff of effects ) await eff.callMacro("onCombatEnd");
-            // else the gm calls it.
-            else if ( !owner && game.user.isGM ) for ( let eff of effects ) await eff.callMacro("onCombatEnd");
+        for ( const [combatant, effects] of combatants ) {
+            // compare against the user who should call these scripts.
+            if ( game.user !== getFirstPlayerOwner(combatant) ) continue;
+            for ( const eff of effects ) await eff.callMacro("onCombatEnd");
         }
     });
 
@@ -129,13 +106,20 @@ export function registerCombatTriggers(){
             return !!CHECKS.hasMacroOfType(eff, "onCombatantDefeated") && CHECKS.isActive(eff);
         });
         if ( !effects.length ) return;
-        
-        // get first active player who is owner of combatant.
-        const owner = combatant.players.filter(i => i.active)[0];
-        
-        // if there is an active player, and that's you, you call this.
-        if ( owner === game.user ) for ( let eff of effects ) await eff.callMacro("onCombatantDefeated");
-        // else the gm calls it.
-        else if ( !owner && game.user.isGM ) for ( let eff of effects ) await eff.callMacro("onCombatantDefeated");
+
+        // compare against the user who should call these scripts.
+        if ( game.user !== getFirstPlayerOwner(combatant) ) return;
+        for ( const eff of effects ) await eff.callMacro("onCombatantDefeated");
     });
+}
+
+// helper function to get the first active player owner, otherwise returns the GM.
+function getFirstPlayerOwner(combatant){
+    const playerOwner = combatant.players.filter(i => i.active)[0];
+    // if the combatant has an active player owner, use that.
+    if ( playerOwner ) return playerOwner;
+
+    // return the first active GM found.
+    const masterOwner = game.users.filter(i => i.isGM && i.active)[0];
+    return masterOwner;
 }

--- a/scripts/triggers/effect.mjs
+++ b/scripts/triggers/effect.mjs
@@ -3,15 +3,25 @@ import { CHECKS, EM } from "../main.mjs";
 export function registerEffectTriggers(){
     // hooks to flag contexts.
     Hooks.on("preDeleteActiveEffect", (effect, context) => {
-        if ( !!CHECKS.hasMacroOfType(effect, "onDelete") && CHECKS.isActive(effect) ) EM.primer(context, "onDelete");
+        if ( CHECKS.hasMacroOfType(effect, "onDelete") && CHECKS.isActive(effect) ) {
+            EM.primer(context, "onDelete");
+        }
     });
-    Hooks.on("preCreateActiveEffect", (effect, effectData, context) => {
-        if ( !!CHECKS.hasMacroOfType(effect, "onCreate") ) EM.primer(context, "onCreate");
+    Hooks.on("preCreateActiveEffect", (effect, _, context) => {
+        if ( CHECKS.hasMacroOfType(effect, "onCreate") ) {
+            EM.primer(context, "onCreate");
+        }
     });
     Hooks.on("preUpdateActiveEffect", (effect, update, context) => {
-        if ( !!CHECKS.hasMacroOfType(effect, "onToggle") && CHECKS.toggled(effect, update) ) EM.primer(context, "onToggle");
-        else if ( !!CHECKS.hasMacroOfType(effect, "onEnable") && CHECKS.toggledOn(effect, update) ) EM.primer(context, "onEnable");
-        else if ( !!CHECKS.hasMacroOfType(effect, "onDisable") && CHECKS.toggledOff(effect, update) ) EM.primer(context, "onDisable");
+        if ( CHECKS.hasMacroOfType(effect, "onToggle") && CHECKS.toggled(effect, update) ) {
+            EM.primer(context, "onToggle");
+        }
+        if ( CHECKS.hasMacroOfType(effect, "onEnable") && CHECKS.toggledOn(effect, update) ) {
+            EM.primer(context, "onEnable");
+        }
+        if ( CHECKS.hasMacroOfType(effect, "onDisable") && CHECKS.toggledOff(effect, update) ) {
+            EM.primer(context, "onDisable");
+        }
     });
 
     // hooks to execute scripts.

--- a/setup.js
+++ b/setup.js
@@ -5,18 +5,18 @@ import { registerEffectTriggers } from "./scripts/triggers/effect.mjs";
 
 // set up prototype functions.
 Hooks.once("setup", () => {
-	ActiveEffect.prototype.callMacro = API.callMacro;
-	ActiveEffect.prototype.removeMacro = API.removeMacro;
-	ActiveEffect.prototype.createMacro = API.createMacro;
-	ActiveEffect.prototype.updateMacro = API.updateMacro;
-	ActiveEffect.prototype.hasMacro = API.hasMacro;
+    ActiveEffect.prototype.callMacro = API.callMacro;
+    ActiveEffect.prototype.removeMacro = API.removeMacro;
+    ActiveEffect.prototype.createMacro = API.createMacro;
+    ActiveEffect.prototype.updateMacro = API.updateMacro;
+    ActiveEffect.prototype.hasMacro = API.hasMacro;
 });
 
 // init msg.
 Hooks.once("init", () => {
     console.log("ZHELL | Initializing Effect Macro");
 
-	registerMacroConfig();
-	registerCombatTriggers();
-	registerEffectTriggers();
+    registerMacroConfig();
+    registerCombatTriggers();
+    registerEffectTriggers();
 });

--- a/templates/macro-menu.html
+++ b/templates/macro-menu.html
@@ -1,28 +1,26 @@
 <form class="editable flexcol" autocomplete="off">
-	<header class="sheet-header">
-		<img src="{{img}}" title="{{name}}" height="64" width="64">
-		<h1>
-			<input name="name" type="text" value="{{name}}" disabled>
-		</h1>
-	</header>
-	
-	<!-- temporary fix for monaco editor -->
-	<div class="form-group" style="display: none;">
-		<select name="type" disabled></select>
-	</div>
-	
-	<div class="form-group stacked command">
-		<label>
-			{{localize "EffectMacro.ApplyMacro.Command"}}
-		</label>
-		<textarea name="command">
-			{{script}}
-		</textarea>
-	</div>
-	
-	<footer class="sheet-footer flexrow">
-		<button type="submit">
-			<i class="fas fa-save"></i> {{localize "EffectMacro.ApplyMacro.Save"}}
-		</button>
-	</footer>
+    <header class="sheet-header">
+        <img src="{{img}}" title="{{name}}" height="64" width="64">
+        <h1>
+            <input name="name" type="text" value="{{name}}" disabled>
+        </h1>
+    </header>
+    
+    <!-- temporary fix for monaco editor -->
+    <div class="form-group" style="display: none;">
+        <select name="type" disabled></select>
+    </div>
+    
+    <div class="form-group stacked command">
+        <label>
+            {{localize "EFFECTMACRO.APPLYMACRO.COMMAND"}}
+        </label>
+        <textarea name="command">{{script}}</textarea>
+    </div>
+    
+    <footer class="sheet-footer flexrow">
+        <button type="submit">
+            <i class="fas fa-save"></i> {{localize "EFFECTMACRO.APPLYMACRO.SAVE"}}
+        </button>
+    </footer>
 </form>


### PR DESCRIPTION
- fixed tabs forced into scripts.
- fixed error that stopped effects from having both `onToggle` and `onDisable/onEnable` scripts.
- `ActiveEffect#createMacro` now supports a function as a parameter, rather than only strings.
- improved code of the combat hooks.
- changed `onCombatStart` to use new `combatStart` hook.
- Closes #15.